### PR TITLE
Add org settings

### DIFF
--- a/api/openapi/apis/organizations.yaml
+++ b/api/openapi/apis/organizations.yaml
@@ -250,6 +250,61 @@ paths:
         - `ADMINISTRATOR`
       tags:
         - Organization
+  '/organizations/{org_id}/settings':
+    parameters:
+      - $ref: '#/components/parameters/organizationId'
+    get:
+      summary: Get organization settings
+      operationId: getOrgSettingsByOrgId
+      tags:
+        - Organization
+      description: |-
+        Get organization settings.
+
+        ### Authority
+
+        - `ADMINISTRATOR`
+        - `MANAGER`
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationSettings'
+        '401':
+          $ref: '#/components/responses/Error'
+        '403':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+    put:
+      summary: Update organization settings
+      operationId: updateOrgSettingsByOrgId
+      tags:
+        - Organization
+      description: |-
+        Update organization settings.
+
+        ### Authority
+
+        - `ADMINISTRATOR`
+        - `MANAGER`
+      responses:
+        '200':
+          $ref: '#/components/responses/Update'
+        '400':
+          $ref: '#/components/responses/Error'
+        '403':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrganizationSettings'
+        description: ''
   '/organizations/{org_id}/users':
     parameters:
       - $ref: '#/components/parameters/organizationId'
@@ -368,11 +423,7 @@ paths:
         description: Definition for a user assignment.
   '/organizations/{org_id}/users/searches':
     parameters:
-      - schema:
-          type: string
-        name: org_id
-        in: path
-        required: true
+      - $ref: '#/components/parameters/organizationId'
     post:
       summary: Create search request for organization users
       operationId: post-organizations-org_id-users-searches
@@ -1033,6 +1084,63 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/OrgUserProject'
+    OrganizationSettings:
+      title: OrganizationSettings
+      type: object
+      properties:
+        retention_policy:
+          type: object
+          description: |-
+            Organisation retention policy settings.
+
+            **Important**: Values for `logs.period` and `attachments.period` cannot exceed the value of `launches.period`.
+            If you set `launches.period` to a value lower than existing `logs.period` or `attachments.period`, those values 
+            will be automatically adjusted to match `launches.period`.
+          properties:
+            launches:
+              type: object
+              description: |-
+                Launches retention policy settings.
+              properties:
+                period:
+                  type: integer
+                  minimum: 0
+                  maximum: 365
+                  description: |-
+                    Number of days to keep launches.
+                    Set `0` to keep attachments forever (retention policy disabled).
+                    This value acts as an upper limit for `logs.period` and `attachments.period`.
+                  default: 90
+            logs:
+              type: object
+              description: |-
+                Logs retention policy settings.
+                The period cannot exceed the value set in `launches.period`.
+              properties:
+                period:
+                  type: integer
+                  minimum: 0
+                  maximum: 365
+                  description: |-
+                    Number of days to keep logs.
+                    Set `0` to keep attachments forever (retention policy disabled).
+                    Cannot exceed the value of `launches.period`.
+                  default: 90
+            attachments:
+              type: object
+              description: |-
+                Attachments retention policy settings.
+                The period cannot exceed the value set in `launches.period`.
+              properties:
+                period:
+                  type: integer
+                  minimum: 0
+                  maximum: 365
+                  description: |-
+                    Number of days to keep attachments. 
+                    Set `0` to keep attachments forever (retention policy disabled).
+                    Cannot exceed the value of `launches.period`.
+                  default: 14
   parameters:
     organizationId:
       name: org_id

--- a/api/openapi/apis/organizations.yaml
+++ b/api/openapi/apis/organizations.yaml
@@ -38,20 +38,28 @@ paths:
         '401':
           $ref: '#/components/responses/Error'
       operationId: get-organizations
+      x-permissions:
+        - role: ADMINISTRATOR
+          access: full
+        - role: MANAGER
+          access: restricted
+          description: |
+            Limited to viewing only their assigned organizations.
+        - role: MEMBER
+          access: restricted
+          description: |
+            Limited to viewing only their assigned organizations.
       description: |-
         Get a list of existing organizations.
 
         ### Authority
 
-        - `ADMINISTRATOR`
-        - `MANAGER`
-        - `MEMBER`
+        - role: ADMINISTRATOR
+        - role: MANAGER
+          access: restricted (Limited to viewing only their assigned organizations)
+        - role: MEMBER
+          access: restricted (Limited to viewing only their assigned organizations)
 
-        ### Access level
-
-        - `ADMINISTRATOR` - no restrictions.
-        - `MANAGER` - limited to viewing only their assigned organizations.
-        - `MEMBER` - limited to viewing only their assigned organizations.
       parameters:
         - $ref: ../parameters/Offset.yaml
         - $ref: ../parameters/Limit.yaml
@@ -258,13 +266,20 @@ paths:
       operationId: getOrgSettingsByOrgId
       tags:
         - Organization
+      x-permissions:
+        - role: ADMINISTRATOR
+          access: full
+        - role: MANAGER
+          access: full
       description: |-
         Get organization settings.
 
         ### Authority
 
-        - `ADMINISTRATOR`
-        - `MANAGER`
+        - role: ADMINISTRATOR
+          access: full
+        - role: MANAGER
+          access: full
       responses:
         '200':
           description: OK
@@ -283,13 +298,20 @@ paths:
       operationId: updateOrgSettingsByOrgId
       tags:
         - Organization
+      x-permissions:
+        - role: ADMINISTRATOR
+          access: full
+        - role: MANAGER
+          access: full
       description: |-
         Update organization settings.
 
         ### Authority
 
-        - `ADMINISTRATOR`
-        - `MANAGER`
+        - role: ADMINISTRATOR
+          access: full
+        - role: MANAGER
+          access: full
       responses:
         '200':
           $ref: '#/components/responses/Update'

--- a/api/openapi/reportportal-api.yaml
+++ b/api/openapi/reportportal-api.yaml
@@ -607,20 +607,27 @@ paths:
         '401':
           $ref: '#/components/responses/Error'
       operationId: get-organizations
+      x-permissions:
+        - role: ADMINISTRATOR
+          access: full
+        - role: MANAGER
+          access: restricted
+          description: |
+            Limited to viewing only their assigned organizations.
+        - role: MEMBER
+          access: restricted
+          description: |
+            Limited to viewing only their assigned organizations.
       description: |-
         Get a list of existing organizations.
 
         ### Authority
 
-        - `ADMINISTRATOR`
-        - `MANAGER`
-        - `MEMBER`
-
-        ### Access level
-
-        - `ADMINISTRATOR` - no restrictions.
-        - `MANAGER` - limited to viewing only their assigned organizations.
-        - `MEMBER` - limited to viewing only their assigned organizations.
+        - role: ADMINISTRATOR
+        - role: MANAGER
+          access: restricted (Limited to viewing only their assigned organizations)
+        - role: MEMBER
+          access: restricted (Limited to viewing only their assigned organizations)
       parameters:
         - $ref: '#/components/parameters/Offset'
         - $ref: '#/components/parameters/Limit'
@@ -846,6 +853,79 @@ paths:
         - Organization
       security:
         - BearerAuth: []
+  /organizations/{org_id}/settings:
+    parameters:
+      - $ref: '#/components/parameters/organizationId'
+    get:
+      summary: Get organization settings
+      operationId: getOrgSettingsByOrgId
+      tags:
+        - Organization
+      x-permissions:
+        - role: ADMINISTRATOR
+          access: full
+        - role: MANAGER
+          access: full
+      description: |-
+        Get organization settings.
+
+        ### Authority
+
+        - role: ADMINISTRATOR
+          access: full
+        - role: MANAGER
+          access: full
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrganizationSettings'
+        '401':
+          $ref: '#/components/responses/Error'
+        '403':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+      security:
+        - BearerAuth: []
+    put:
+      summary: Update organization settings
+      operationId: updateOrgSettingsByOrgId
+      tags:
+        - Organization
+      x-permissions:
+        - role: ADMINISTRATOR
+          access: full
+        - role: MANAGER
+          access: full
+      description: |-
+        Update organization settings.
+
+        ### Authority
+
+        - role: ADMINISTRATOR
+          access: full
+        - role: MANAGER
+          access: full
+      responses:
+        '200':
+          $ref: '#/components/responses/Update'
+        '400':
+          $ref: '#/components/responses/Error'
+        '403':
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OrganizationSettings'
+        description: ''
+      security:
+        - BearerAuth: []
   /organizations/{org_id}/users:
     parameters:
       - $ref: '#/components/parameters/organizationId'
@@ -984,11 +1064,7 @@ paths:
         - BearerAuth: []
   /organizations/{org_id}/users/searches:
     parameters:
-      - schema:
-          type: string
-        name: org_id
-        in: path
-        required: true
+      - $ref: '#/components/parameters/organizationId'
     post:
       summary: Create search request for organization users
       operationId: post-organizations-org_id-users-searches
@@ -3202,6 +3278,77 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/OrgUserProject'
+    OrganizationSettings:
+      title: OrganizationSettings
+      type: object
+      properties:
+        retention_policy:
+          type: object
+          description: >-
+            Organisation retention policy settings.
+
+
+            **Important**: Values for `logs.period` and `attachments.period`
+            cannot exceed the value of `launches.period`.
+
+            If you set `launches.period` to a value lower than existing
+            `logs.period` or `attachments.period`, those values 
+
+            will be automatically adjusted to match `launches.period`.
+          properties:
+            launches:
+              type: object
+              description: Launches retention policy settings.
+              properties:
+                period:
+                  type: integer
+                  minimum: 0
+                  maximum: 365
+                  description: >-
+                    Number of days to keep launches.
+
+                    Set `0` to keep attachments forever (retention policy
+                    disabled).
+
+                    This value acts as an upper limit for `logs.period` and
+                    `attachments.period`.
+                  default: 90
+            logs:
+              type: object
+              description: |-
+                Logs retention policy settings.
+                The period cannot exceed the value set in `launches.period`.
+              properties:
+                period:
+                  type: integer
+                  minimum: 0
+                  maximum: 365
+                  description: >-
+                    Number of days to keep logs.
+
+                    Set `0` to keep attachments forever (retention policy
+                    disabled).
+
+                    Cannot exceed the value of `launches.period`.
+                  default: 90
+            attachments:
+              type: object
+              description: |-
+                Attachments retention policy settings.
+                The period cannot exceed the value set in `launches.period`.
+              properties:
+                period:
+                  type: integer
+                  minimum: 0
+                  maximum: 365
+                  description: >-
+                    Number of days to keep attachments. 
+
+                    Set `0` to keep attachments forever (retention policy
+                    disabled).
+
+                    Cannot exceed the value of `launches.period`.
+                  default: 14
     OrganizationBase:
       title: Organization definition
       description: >


### PR DESCRIPTION
This pull request introduces enhancements to the OpenAPI specifications for both `organizations.yaml` and `reportportal-api.yaml`. Key changes include the addition of a new `OrganizationSettings` schema, updates to permission structures, and the introduction of new endpoints for managing organization settings.

### Enhancements to OpenAPI Specifications:

#### Permission Updates:
* Updated the `x-permissions` field for existing endpoints to provide detailed role-based access levels for `ADMINISTRATOR`, `MANAGER`, and `MEMBER`. These changes clarify access restrictions for each role. (`[[1]](diffhunk://#diff-c70edcaeef3cd59ef6a9bfc00503edab1508fffff5fe9ea130d7272aa0fb5fa8R41-L54)`, `[[2]](diffhunk://#diff-a206a55a37f02c5785ef080cfb14cc1969e2906e05bc9616aaaa7c0d4c0b4f83R610-R630)`)

#### New Endpoints for Organization Settings:
* Added `GET` and `PUT` endpoints under `/organizations/{org_id}/settings` for retrieving and updating organization settings. These endpoints include role-based access control and detailed descriptions of their functionality. (`[[1]](diffhunk://#diff-c70edcaeef3cd59ef6a9bfc00503edab1508fffff5fe9ea130d7272aa0fb5fa8R261-R329)`, `[[2]](diffhunk://#diff-a206a55a37f02c5785ef080cfb14cc1969e2906e05bc9616aaaa7c0d4c0b4f83R856-R928)`)

#### Parameter Standardization:
* Replaced inline `org_id` parameter definitions with a reusable reference to `#/components/parameters/organizationId` for consistency across endpoints. (`[[1]](diffhunk://#diff-c70edcaeef3cd59ef6a9bfc00503edab1508fffff5fe9ea130d7272aa0fb5fa8L371-R448)`, `[[2]](diffhunk://#diff-a206a55a37f02c5785ef080cfb14cc1969e2906e05bc9616aaaa7c0d4c0b4f83L987-R1067)`)

#### New Schema for Organization Settings:
* Introduced the `OrganizationSettings` schema, which includes detailed properties for `retention_policy` settings. This schema defines retention periods for `launches`, `logs`, and `attachments`, ensuring constraints between these fields are documented. (`[[1]](diffhunk://#diff-c70edcaeef3cd59ef6a9bfc00503edab1508fffff5fe9ea130d7272aa0fb5fa8R1109-R1165)`, `[[2]](diffhunk://#diff-a206a55a37f02c5785ef080cfb14cc1969e2906e05bc9616aaaa7c0d4c0b4f83R3281-R3351)`)